### PR TITLE
Removed 's' from 'teamproposals'

### DIFF
--- a/hflossk/templates/blogs.mak
+++ b/hflossk/templates/blogs.mak
@@ -28,7 +28,7 @@
             <li><a target="_blank" href="${forge_link}">${forge_link}</a></li>
           % endfor
 
-          <% keys = ['quiz1', 'litreview1', 'bugfix', 'commarch', 'teamproposals'] %>
+          <% keys = ['quiz1', 'litreview1', 'bugfix', 'commarch', 'teamproposal'] %>
           % for key in keys:
               % if student.get(key):
                 <li><a target="_blank" href="${student[key]}">${key}</a></li>


### PR DESCRIPTION
Everyone's yaml file has "teamproposal" instead of "teamproposals," because that's what we originally told to put.
