### PR TITLE
Fixed w02c1 being called w1c2 on the w02c1 page

### DIFF
--- a/hflossk/templates/lectures/w02c1.mak
+++ b/hflossk/templates/lectures/w02c1.mak
@@ -1,8 +1,8 @@
 <%inherit file="../master.mak" />
 
 <div class="jumbotron">
-    <h1>W1C2</h1>
-    <p>Week 1 - Class 2</p>
+    <h1>W2C1</h1>
+    <p>Week 2 - Class 1</p>
 </div>
 
 <div>


### PR DESCRIPTION
On the week 2 class 1 page, it was being referred to as week 1 class 2. I fix, I fix.
