### PR TITLE
Deploy with Tornado for hyper speed.

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,10 +9,9 @@ if __name__ == "__main__":
     if 'OPENSHIFT_PYTHON_IP' in os.environ:
         host = os.environ['OPENSHIFT_PYTHON_IP']
         port = int(os.environ['OPENSHIFT_PYTHON_PORT'])
-        app.run(host=host, port=port)
-	http_server = HTTPServer(WSGIContainer(app))
-	http_server.listen(port, address=host)
-	IOLoop.instance().start()
+        http_server = HTTPServer(WSGIContainer(app))
+        http_server.listen(port, address=host)
+        IOLoop.instance().start()
     else:
         app.debug = True
         app.run()

--- a/app.py
+++ b/app.py
@@ -1,12 +1,18 @@
 import os
 
 from hflossk.site import app
+from tornado.wsgi import WSGIContainer
+from tornado.httpserver import HTTPServer
+from tornado.ioloop import IOLoop
 
 if __name__ == "__main__":
     if 'OPENSHIFT_PYTHON_IP' in os.environ:
         host = os.environ['OPENSHIFT_PYTHON_IP']
         port = int(os.environ['OPENSHIFT_PYTHON_PORT'])
         app.run(host=host, port=port)
+	http_server = HTTPServer(WSGIContainer(app))
+	http_server.listen(port, address=host)
+	IOLoop.instance().start()
     else:
         app.debug = True
         app.run()

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "feedparser",
         "pyyaml",
         "frozen-flask",
+	"tornado"
     ],
     #TODO: Deal with entry_points
     #entry_points="""


### PR DESCRIPTION
The built-in Python HTTP server isn't really cut out for a production deployment. This change tells Openshift to deploy HFLOSSK with Tornado. When run in debug mode (locally) it'll still run with the built-in Python HTTP server.
