### PR TITLE
Fix RSS Feed link

### DIFF
--- a/scripts/people/2014/fall/MrNex.yaml
+++ b/scripts/people/2014/fall/MrNex.yaml
@@ -1,5 +1,5 @@
 blog: http://nexleveldevelopment.wordpress.com
-feed: http://en.nexleveldevelopment.wordpress.com/feed/
+feed: http://nexleveldevelopment.wordpress.com/feed/
 forges:
   - http://github.com/MrNex
 irc: MrNex


### PR DESCRIPTION
RSS feed seemed to not be working. Removed "en" prefix in hopes it will address the issue.
